### PR TITLE
Ability to handle default for array of type string

### DIFF
--- a/.github/e2e/values1.schema.json
+++ b/.github/e2e/values1.schema.json
@@ -321,6 +321,9 @@
     },
     "tolerations": {
       "type": "array",
+      "default": [
+        ""
+      ],
       "items": {
         "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.24.0/_definitions.json#/definitions/io.k8s.api.core.v1.Toleration"
       }

--- a/.github/e2e/values3.schema.json
+++ b/.github/e2e/values3.schema.json
@@ -5,7 +5,8 @@
     "pullPolicy",
     "name",
     "replicaCount",
-    "username"
+    "username",
+    "syncOptions"
   ],
   "properties": {
     "pullPolicy": {
@@ -43,6 +44,19 @@
       "maxLength": 15,
       "title": "Username with limited length range",
       "default": "banshee86vr"
+    },
+    "syncOptions": {
+      "type": "array",
+      "title": "Options allow you to specify whole app sync-options",
+      "items": {
+        "type": [
+          "string"
+        ]
+      },
+      "default": [
+        "CreateNamespace=true",
+        "test=4"
+      ]
     }
   }
 }

--- a/.github/e2e/values3.schema.json
+++ b/.github/e2e/values3.schema.json
@@ -47,16 +47,17 @@
     },
     "syncOptions": {
       "type": "array",
+      "default": [
+        "CreateNamespace=true",
+        "Prune=false",
+        "SkipDryRunOnMissingResource=true"
+      ],
       "title": "Options allow you to specify whole app sync-options",
       "items": {
         "type": [
           "string"
         ]
-      },
-      "default": [
-        "CreateNamespace=true",
-        "test=4"
-      ]
+      }
     }
   }
 }

--- a/.github/e2e/values3.yaml
+++ b/.github/e2e/values3.yaml
@@ -6,3 +6,7 @@ name: JSONSchemaGenerator
 replicaCount: 3
 # @param {string{minLength=10,maxLength=15}} username Username with limited length range
 username: banshee86vr
+# @param {string[]} syncOptions Options allow you to specify whole app sync-options
+syncOptions:
+  - CreateNamespace=true
+  - test=4

--- a/.github/e2e/values3.yaml
+++ b/.github/e2e/values3.yaml
@@ -6,7 +6,5 @@ name: JSONSchemaGenerator
 replicaCount: 3
 # @param {string{minLength=10,maxLength=15}} username Username with limited length range
 username: banshee86vr
-# @param {string[]} syncOptions Options allow you to specify whole app sync-options
-syncOptions:
-  - CreateNamespace=true
-  - test=4
+# @param {string[CreateNamespace=true,Prune=false,SkipDryRunOnMissingResource=true]} syncOptions Options allow you to specify whole app sync-options
+syncOptions: []

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "dev": "tsc --watch --outDir build",
     "build": "ncc build ./src/index.ts",
     "test": "jest",
-    "snapshots": "yarn build && yarn test -u && ./bin/index.js -f .github/e2e/values3.yaml > .github/e2e/values3.schema.json",
+    "snapshots": "yarn build && yarn test -u && ./bin/index.js -f .github/e2e/values1.yaml > .github/e2e/values1.schema.json && ./bin/index.js -f .github/e2e/values2.yaml > .github/e2e/values2.schema.json && ./bin/index.js -f .github/e2e/values3.yaml > .github/e2e/values3.schema.json",
     "lint": "eslint src/**/*.ts"
   },
   "dependencies": {

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -22,6 +22,7 @@ exports[`extractValues: JSDoc with ref array 1`] = `
   {
     "comment": {
       "description": "",
+      "isArray": true,
       "items": {
         "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.24.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvFromSource",
       },
@@ -39,6 +40,7 @@ exports[`extractValues: JSDoc with string array 1`] = `
   {
     "comment": {
       "description": "",
+      "isArray": true,
       "items": {
         "type": [
           "string",
@@ -314,6 +316,7 @@ exports[`toJsonSchema: JSDoc with ref array 1`] = `
   "$schema": "http://json-schema.org/draft-07/schema",
   "properties": {
     "envFrom": {
+      "default": undefined,
       "items": {
         "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.24.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvFromSource",
       },
@@ -332,6 +335,7 @@ exports[`toJsonSchema: JSDoc with string array 1`] = `
   "$schema": "http://json-schema.org/draft-07/schema",
   "properties": {
     "command": {
+      "default": undefined,
       "items": {
         "type": [
           "string",
@@ -394,6 +398,7 @@ exports[`toJsonSchema: YAML with external references 1`] = `
     "securityContext": {
       "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.24.0/_definitions.json#/definitions/io.k8s.api.core.v1.PodSecurityContext",
       "description": "Setup your securityContext to reduce security risks, see https://kubernetes.io/docs/tasks/configure-pod-container/security-context/",
+      "type": undefined,
     },
   },
   "required": [

--- a/src/__snapshots__/index.test.ts.snap
+++ b/src/__snapshots__/index.test.ts.snap
@@ -21,6 +21,9 @@ exports[`extractValues: JSDoc with ref array 1`] = `
 [
   {
     "comment": {
+      "arrayDefaults": [
+        "",
+      ],
       "description": "",
       "isArray": true,
       "items": {
@@ -39,6 +42,9 @@ exports[`extractValues: JSDoc with string array 1`] = `
 [
   {
     "comment": {
+      "arrayDefaults": [
+        "",
+      ],
       "description": "",
       "isArray": true,
       "items": {
@@ -316,7 +322,9 @@ exports[`toJsonSchema: JSDoc with ref array 1`] = `
   "$schema": "http://json-schema.org/draft-07/schema",
   "properties": {
     "envFrom": {
-      "default": undefined,
+      "default": [
+        "",
+      ],
       "items": {
         "$ref": "https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master/v1.24.0/_definitions.json#/definitions/io.k8s.api.core.v1.EnvFromSource",
       },
@@ -335,7 +343,9 @@ exports[`toJsonSchema: JSDoc with string array 1`] = `
   "$schema": "http://json-schema.org/draft-07/schema",
   "properties": {
     "command": {
-      "default": undefined,
+      "default": [
+        "",
+      ],
       "items": {
         "type": [
           "string",


### PR DESCRIPTION
It's possible to define default values for array field in this way:

```yaml
# @param {string[CreateNamespace=true,Prune=false,SkipDryRunOnMissingResource=true]} syncOptions Options allow you to specify whole app sync-options
syncOptions: []
```

The string between two squared parentheses will be split by a comma and added to default list values.

Is it suitable to address your issue correctly?